### PR TITLE
Take custom parsers into account when using an "or" holder

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -20,6 +20,11 @@ declare type Holder = {
   type: 'holder'
 };
 
+declare type Or = {
+  children: Children,
+  type: 'or'
+};
+
 declare type Children = {
   [string]: Child | Holder
 };

--- a/test/index.js
+++ b/test/index.js
@@ -308,6 +308,32 @@ describe('config', () => {
 
     describe('parser', () => {
 
+      it('should take custom parsers into account when using an "or" holder', () => {
+        let called = false;
+
+        const lookupFn = createLookupFn({
+          foo: 'bar'
+        });
+
+        const parser = (value) => {
+          assert.equal(value, 'bar');
+          called = true;
+
+          return 'test';
+        };
+
+        const unmarshaller = {
+          foo: builder.or(
+            builder.string('foo', {parser})
+          )
+        };
+
+        const config = unmarshal(lookupFn, unmarshaller);
+
+        assert.equal(config.foo, 'test');
+        assert.isTrue(called);
+      });
+
       it('should use a custom parser', () => {
         let called = false;
 


### PR DESCRIPTION
Currently custom parsers are ignored when using an "or" holder, this PR aims to fix this.